### PR TITLE
Jyt new name

### DIFF
--- a/lib/jyt.parser.js
+++ b/lib/jyt.parser.js
@@ -82,8 +82,8 @@ function parse(html, opts, cb) {
     var options = {
         ignoreWhitespace: true
     };
-    if(opts) {
-        if(typeof opts == 'function') {
+    if (opts) {
+        if (typeof opts === 'function') {
             if (cb) {
                 options = opts();
             }
@@ -91,9 +91,11 @@ function parse(html, opts, cb) {
                 cb = opts;
             }
         }
-        else if(typeof opts == 'object') {
-            for(var i in opts) {
-                options[i] = opts[i];
+        else if (typeof opts === 'object') {
+            for (var i in opts) {
+                if (opts.hasOwnProperty(i)) {
+                    options[i] = opts[i];
+                }
             }
         }
     }

--- a/lib/jyt.runtime.js
+++ b/lib/jyt.runtime.js
@@ -12,7 +12,7 @@ var allTags = ['a', 'iframe', 'abbr', 'acronym', 'address', 'area', 'b', 'base',
     'input', 'ins', 'kbd', 'label', 'legend', 'li', 'link', 'map', 'meta', 'noscript',
     'object', 'ol', 'optgroup', 'option', 'p', 'param', 'pre', 'q', 's', 'samp', 'script',
     'select', 'small', 'span', 'strong', 'style', 'sub', 'sup', 'table', 'tbody',
-    'td', 'textarea', 'tfoot', 'th', 'thead', 'title', 'tr', 'tt', 'u', 'ul'];
+    'td', 'textarea', 'tfoot', 'th', 'thead', 'title', 'tr', 'tt', 'u', 'ul', 'canvas'];
 var selfClosing = ['area', 'base', 'basefont', 'br', 'col', 'frame', 'hr',
     'img', 'input', 'link', 'meta', 'param'];
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jyt",
-  "version": "0.1.127",
+  "version": "0.1.128",
   "description": "JavaScript Your Templates",
   "main": "lib/jyt.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "jyt",
+  "name": "rl-jyt",
   "version": "0.1.128",
   "description": "JavaScript Your Templates",
   "main": "lib/jyt.js",
   "repository": {
     "type": "git",
-    "url": "git://github.com/gethuman/jyt.git"
+    "url": "git://github.com/rocketlawyer/jyt.git"
   },
   "keywords": [
     "javascript",
@@ -14,9 +14,9 @@
   "author": "Jeff Whelpley",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/gethuman/jyt/issues"
+    "url": "https://github.com/rocketlawyer/jyt/issues"
   },
-  "homepage": "https://github.com/gethuman/jyt",
+  "homepage": "https://github.com/rocketlawyer/jyt",
   "dependencies": {
     "htmlparser": "1.7.7"
   },
@@ -24,5 +24,11 @@
     "batter": "^0.1.51",
     "gulp": "3.9.1",
     "taste": "^0.2.41"
+  },
+  "scripts": {
+    "gulp": "gulp"
+  },
+  "publishConfig": {
+    "registry": "https://rocketlawyer.jfrog.io/rocketlawyer/api/npm/npm-local"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jyt",
-  "version": "0.1.128",
+  "version": "0.1.129",
   "description": "JavaScript Your Templates",
   "main": "lib/jyt.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "htmlparser": "1.7.7"
   },
   "devDependencies": {
-    "batter": "^0.1.51",
+    "batter": "^0.1.52",
     "gulp": "3.9.1",
-    "taste": "^0.2.42"
+    "taste": "^0.2.43"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   "devDependencies": {
     "batter": "^0.1.51",
     "gulp": "3.9.1",
-    "taste": "^0.2.41"
+    "taste": "^0.2.42"
   }
 }


### PR DESCRIPTION
We must not use the name of an existing package, changing the name to rl-jyt and fixing the linting issues.